### PR TITLE
[Peterborough] Allow insecure curl requests

### DIFF
--- a/bin/peterborough-layer-update
+++ b/bin/peterborough-layer-update
@@ -9,7 +9,7 @@ TMPDIR=$(mktemp -d) || exit 1
 trap 'rm -rf "$TMPDIR"' EXIT
 cd $TMPDIR
 
-curl -sS -O -u "$OPTION_peterborough__username:$OPTION_peterborough__password" \
+curl -k -sS -O -u "$OPTION_peterborough__username:$OPTION_peterborough__password" \
     "sftp://${OPTION_peterborough__host}${OPTION_peterborough__dir}/trees_invent.zip"
 unzip trees_invent.zip
 


### PR DESCRIPTION
Without this we get the following error:

    curl: (51) SSL peer certificate or SSH remote key was not OK

I'm not sure how I missed this before, thought I'd tested the script on staging but apparently not 😕 