### PR TITLE
Update layer URLs to ensure they are properly encoded and add error reporting

### DIFF
--- a/bin/buckinghamshire-layer-update
+++ b/bin/buckinghamshire-layer-update
@@ -22,7 +22,7 @@ HWLightingAsset
 "
 
 for layer in $LAYERS; do
-    curl -s -O -u $OPTION_buckinghamshire__username:$OPTION_buckinghamshire__password \
+    curl -s -S -O -u $OPTION_buckinghamshire__username:$OPTION_buckinghamshire__password \
     "sftp://$OPTION_buckinghamshire__host$OPTION_buckinghamshire__dir/$layer.{dat,id,map,TAB}"
     ogr2ogr -where "feature_end_date = '3000/01/01'" ${layer}Live.tab ${layer}.TAB
 done

--- a/bin/isleofwight-layer-update
+++ b/bin/isleofwight-layer-update
@@ -82,14 +82,14 @@ Verges-Natural
 "
 
 for layer in $LAYERS; do
-curl -s -O -u $OPTION_isleofwight__username:$OPTION_isleofwight__password \
+curl -s -S -O -u $OPTION_isleofwight__username:$OPTION_isleofwight__password \
     "sftp://$OPTION_isleofwight__host$OPTION_isleofwight__dir/$layer.{dat,id,map,tab}"
     sleep 1
 done;
 
 rename 's/ /_/g' *
 
-curl -s -O -u $OPTION_isleofwight__username:$OPTION_isleofwight__password \
+curl -s -S -O -u $OPTION_isleofwight__username:$OPTION_isleofwight__password \
   "sftp://$OPTION_isleofwight__host$OPTION_isleofwight__streetdir/Streets.{dat,id,map,tab}"
 
 mv *.{dat,id,map,tab} $OPTION_isleofwight__out

--- a/bin/isleofwight-layer-update
+++ b/bin/isleofwight-layer-update
@@ -82,12 +82,13 @@ Verges-Natural
 "
 
 for layer in $LAYERS; do
-curl -s -S -O -u $OPTION_isleofwight__username:$OPTION_isleofwight__password \
-    "sftp://$OPTION_isleofwight__host$OPTION_isleofwight__dir/$layer.{dat,id,map,tab}"
+    layer_encoded=$(echo $layer | sed -e 's/ /%20/g')
+    curl -s -S -O -u $OPTION_isleofwight__username:$OPTION_isleofwight__password \
+         "sftp://$OPTION_isleofwight__host$OPTION_isleofwight__dir/${layer_encoded}.{dat,id,map,tab}"
     sleep 1
 done;
 
-rename 's/ /_/g' *
+rename 's/%20/_/g' *
 
 curl -s -S -O -u $OPTION_isleofwight__username:$OPTION_isleofwight__password \
   "sftp://$OPTION_isleofwight__host$OPTION_isleofwight__streetdir/Streets.{dat,id,map,tab}"

--- a/bin/lincolnshire-layer-update
+++ b/bin/lincolnshire-layer-update
@@ -31,9 +31,12 @@ Divisional/Verges/LCC Verges
 "
 
 for layer in $LAYERS; do
-curl -s -S -O -u $OPTION_lincolnshire__username:$OPTION_lincolnshire__password \
-    "sftp://$OPTION_lincolnshire__host$OPTION_lincolnshire__dir/$layer.{DAT,ID,IND,MAP,TAB}"
+    layer_encoded=$(echo $layer | sed -e 's/ /%20/g')
+    curl -s -S -O -u $OPTION_lincolnshire__username:$OPTION_lincolnshire__password \
+         "sftp://$OPTION_lincolnshire__host$OPTION_lincolnshire__dir/${layer_encoded}.{DAT,ID,IND,MAP,TAB}"
     sleep 1
 done;
+
+rename 's/%20/_/g' *
 
 mv *.{DAT,ID,IND,MAP,TAB} $OPTION_lincolnshire__out


### PR DESCRIPTION
This ensures that where necessary layer URLs being fetched by curl have spaces encoded when requested.

The resulting filenames are renamed to use underscores for spaces - note that this is a slight change for Lincolnshire, which may need to be considered elsewhere.

It also adds error reporting to some of the commands, as this wasn't enabled everywhere.

Fixes #37 