### PR TITLE
[Central Beds] Add script to update aurora asset layers.

### DIFF
--- a/bin/centralbedfordshire-aurora-layer-update
+++ b/bin/centralbedfordshire-aurora-layer-update
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -eo pipefail
+
+source /data/mysociety/shlib/deployfns
+read_conf "$(dirname "$0")/../conf/general.yml"
+
+CONTAINER_URL="$OPTION_centralbedfordshire__container_url"
+SAS_TOKEN="$OPTION_centralbedfordshire__sas_token"
+OUT_DIR="$OPTION_centralbedfordshire__out"
+
+if ! command -v azcopy &> /dev/null; then
+    echo "Error: azcopy is not installed"
+    exit 1
+fi
+
+# List all .zip files with their properties, sorted by last modified (newest first).
+LATEST_BLOB=$(azcopy list "${CONTAINER_URL}?${SAS_TOKEN}" --properties LastModifiedTime \
+    | grep '\.zip;' \
+    | sort -t';' -k2 -r \
+    | head -1 \
+    | cut -d';' -f1)
+
+if [ -z "$LATEST_BLOB" ]; then
+    echo "No .zip files found"
+    exit 1
+fi
+
+# Create temp directory for download.
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Download the file.
+azcopy copy "${CONTAINER_URL}/${LATEST_BLOB}?${SAS_TOKEN}" "$TEMP_DIR/"
+
+# Extract it.
+mkdir "$TEMP_DIR/extracted"
+unzip -o "$TEMP_DIR/${LATEST_BLOB}" -d "$TEMP_DIR/extracted"
+
+# The main reason for doing this is the "Asset Refe" and "Internal A" attributes
+# contain spaces which mapserver struggles with - the filtering is just a drive-by
+# since we're already processing the files.
+cd "$TEMP_DIR/extracted"
+ogr2ogr LightingPoint.shp Assetpoint.shp -sql \
+    "SELECT \"Internal A\" as unit_id, \"Asset Refe\" AS asset_ref \
+    FROM Assetpoint \
+    WHERE \"Asset Type\" = 'Lighting Point'"
+ogr2ogr GritBin.shp Assetpoint.shp -sql \
+    "SELECT \"Internal A\" as unit_id, \"Asset Refe\" AS asset_ref \
+    FROM Assetpoint \
+    WHERE \"Asset Type\" = 'Grit Bin'"
+ogr2ogr Street.shp Assetline.shp -sql \
+    "SELECT \"Internal A\" as unit_id, \"Asset Refe\" AS asset_ref \
+    FROM Assetline \
+    WHERE \"Asset Type\" = 'Street'"
+
+# Move generated shapefiles to out destination.
+mkdir -p "$OUT_DIR"
+mv LightingPoint.* GritBin.* Street.* "$OUT_DIR"

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -5,6 +5,11 @@ buckinghamshire:
     dir: /dir
     out: /data/vhost/layers/
 
+centralbedfordshire:
+    container_url: url
+    sas_token: sas_token
+    out: /data/vhost/layers/
+
 isleofwight:
     host: host
     username: username


### PR DESCRIPTION
For https://github.com/mysociety/societyworks/issues/5292.

See `308757` in puppet repo for setting up `azcopy` package on tilma (or message `Tilma: Add azcopy microsoft package.` in case of rebase).
See `db09aa` in servers repo for config.
See `3114ef` in servers repo for cron. Set up for 5am every Sunday. Export to Azure container seems to be around 2am every Sunday. 

Verified by manually running the script on `swstgtilma001sovb`.
