### PR TITLE
Parameterise graphql response result key via config.

### DIFF
--- a/web/confirm.php
+++ b/web/confirm.php
@@ -15,7 +15,7 @@ $n = $bbox[3];
 
 $poly = "POLYGON (($w $n, $e $n, $e $s, $w $s, $w $n))";
 $params = [ "query" => str_replace("__BBOX__", $poly, $layer_cfg['query']) ];
-$result = make_request($cfg['url'], $cfg['key'], $params, "Basic")->data->jobs;
+$result = make_request($cfg['url'], $cfg['key'], $params, "Basic")->data->{$layer_cfg['results_key']};
 
 foreach ($result as $feature) {
     if (!$layer_cfg['filter'] || $layer_cfg['filter']($feature)) {


### PR DESCRIPTION
For tilma part of https://github.com/mysociety/societyworks/issues/5345.

In `tilma_conf_config.yaml` in the servers repo, please also review:
* Adding `results_key` to existing gloucestershire config.
* New aberdeenshire grit bin query + function to extract attributes.