### PR TITLE
[Rutland] Fetch lighting layer from sftp

### DIFF
--- a/bin/rutland-layer-update
+++ b/bin/rutland-layer-update
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+source /data/mysociety/shlib/deployfns
+read_conf "$(dirname "$0")/../conf/general.yml"
+
+# Ensure that the SSH keys for the SFTP server have been accepted
+[ -e ~/.ssh/known_hosts ] || install -D -m 0644 /dev/null ~/.ssh/known_hosts
+grep $OPTION_rutland__host  ~/.ssh/known_hosts >/dev/null || ssh-keyscan $OPTION_rutland__host >> ~/.ssh/known_hosts
+
+TMPDIR=$(mktemp -d) || exit 1
+trap 'rm -rf "$TMPDIR"' EXIT
+cd $TMPDIR
+
+curl -sS -O -u "$OPTION_rutland__username:$OPTION_rutland__password" \
+    "sftp://${OPTION_rutland__host}${OPTION_rutland__dir}/street_lighting.{dbf,prj,shp,shx}"
+
+mv ./*.{dbf,prj,shp,shx} "$OPTION_rutland__out"

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -46,5 +46,12 @@ lincolnshire:
     dir: /dir
     out: /data/vhost/layers
 
+rutland:
+    host: host
+    username: username
+    password: password
+    dir: /dir
+    out: /data/vhost/layers
+
 shropshire:
     out: /data/vhost/layers


### PR DESCRIPTION
Most likely way forward is to be calling these from sftp so initialise this for testing.

https://3.basecamp.com/4020879/buckets/45537679/todos/9506068725#__recording_9637508674

Companion branch on the servers in ```rutland-update-layer```
